### PR TITLE
Clean up required internal dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,5 @@
     <url type="documentation">https://github.com/mnesarco/Channels/wiki/</url>
     <url type="readme">https://github.com/mnesarco/Channels/blob/main/README.md</url>
     <url type="repository" branch="main">https://github.com/mnesarco/Channels/</url>
-    <depend type="internal">Import</depend>
-    <depend type="internal">Part</depend>
+    <depend type="internal">part</depend>
 </package>


### PR DESCRIPTION
"Import" isn't an internal workbench that the Addon Manager knows about, so there can't be a dependency on it. And for other internal workbenches, the addon manager expects all lowercase. I'll fix those issues on the Addon Manager end as well, but if you want to support older versions I suggest making the changes proposed here.